### PR TITLE
UTC TimeZone instead of LA TimeZone?

### DIFF
--- a/src/engine/world/WorldController.js
+++ b/src/engine/world/WorldController.js
@@ -17,7 +17,7 @@ export default class WorldController extends BaseScene {
 
         this.globalLoadQueue = {}
 
-        this.worldTimeZone = 'America/Los_Angeles'
+        this.worldTimeZone = 'Etc/UTC'
     }
 
     create() {


### PR DESCRIPTION
Update to UTC TimeZone it is a universal timezone used in most games with an in-game clock, It is Easier to plan events around as everyone can convert UTC to their timezone more easily.