### PR TITLE
Unload assets when leaving room

### DIFF
--- a/src/engine/interface/InterfaceController.js
+++ b/src/engine/interface/InterfaceController.js
@@ -189,7 +189,7 @@ export default class InterfaceController extends BaseScene {
 
         const text = this.getWidgetLoadString(preload.loadString)
 
-        this.prompt.showLoading(text, preload.key, preload.url, () => {
+        this.prompt.showLoading(text, preload.key, preload.url, preload.unload, () => {
             callback()
         })
     }

--- a/src/engine/interface/prompt/LoadingPromptFactory.js
+++ b/src/engine/interface/prompt/LoadingPromptFactory.js
@@ -9,13 +9,24 @@ export default class LoadingPromptFactory {
         this.prompts = {}
     }
 
-    showLoading(text, key, url, callback) {
+    get world() {
+        return this.interface.world
+    }
+
+    showLoading(text, key, url, unload = true, callback) {
         if (key in this.prompts) {
             return this.updatePrompt(key)
         }
 
         let prompt = this.createPrompt()
         this.prompts[key] = prompt
+
+        if (unload) {
+            prompt.packFileLoader.on('filecomplete', (key, type, data) => {
+                this.world.loadedAssets.push({id: key, type})
+                console.log(key)
+            })
+        }
 
         prompt.packFileLoader.on('complete', () => {
             prompt.destroy()

--- a/src/engine/interface/prompt/PromptController.js
+++ b/src/engine/interface/prompt/PromptController.js
@@ -88,8 +88,8 @@ export default class PromptController {
         this.window.show(text, buttonLayout, callback, noCallback)
     }
 
-    showLoading(text, key, url, callback = () => {}) {
-        this.loadingPromptFactory.showLoading(text, key, url, callback)
+    showLoading(text, key, url, unload, callback = () => {}) {
+        this.loadingPromptFactory.showLoading(text, key, url, unload, callback)
     }
 
     showMailError(text) {

--- a/src/engine/world/WorldController.js
+++ b/src/engine/world/WorldController.js
@@ -18,6 +18,8 @@ export default class WorldController extends BaseScene {
         this.globalLoadQueue = {}
 
         this.worldTimeZone = 'America/Los_Angeles'
+
+        this.loadedAssets = []
     }
 
     create() {

--- a/src/engine/world/room/RoomFactory.js
+++ b/src/engine/world/room/RoomFactory.js
@@ -91,7 +91,7 @@ export default class RoomFactory {
             }
 
             for (let anim in this.world.room.anims.anims.entries) {
-                if (this.world.room.anims.anims.entries[anim].frames[0].textureKey == item.id) {
+                if (this.world.room.anims.anims.entries[anim].frames[0].textureKey == item.id || this.world.room.anims.anims.entries[anim].key.startsWith(item.id)) {
                     anims++
                     delete this.world.room.anims.anims.entries[anim]
                 }

--- a/src/engine/world/room/RoomFactory.js
+++ b/src/engine/world/room/RoomFactory.js
@@ -11,6 +11,8 @@ export default class RoomFactory {
     }
 
     create(args) {
+        this.unloadPrevious()
+
         if (args.room) {
             return this.createRoom(args)
 
@@ -60,4 +62,82 @@ export default class RoomFactory {
         return this.createRoom({ room: args.game })
     }
 
+    unloadPrevious() {
+        if (!this.world.room) return
+        let textures = 0
+        let json = 0
+        let audio = 0
+        let video = 0
+        let anims = 0
+
+        for (let item of this.world.loadedAssets) {
+            if (Object.keys(this.world.room.textures.list).includes(item.id)) {
+                textures++
+                this.world.room.textures.remove(item.id)
+            }
+
+            if (Object.keys(this.world.cache.json.entries.entries).includes(item.id)) {
+                this.world.room.cache.json.remove(item.id)
+                json++
+            }
+
+            if (Object.keys(this.world.cache.audio.entries.entries).includes(item.id)) {
+                this.world.room.cache.audio.remove(item.id)
+                audio++
+            }
+
+            if (Object.keys(this.world.cache.video.entries.entries).includes(item.id)) {
+                this.world.room.cache.video.remove(item.id)
+            }
+
+            for (let anim in this.world.room.anims.anims.entries) {
+                if (this.world.room.anims.anims.entries[anim].frames[0].textureKey == item.id) {
+                    anims++
+                    delete this.world.room.anims.anims.entries[anim]
+                }
+            }
+        }
+
+        for (let item of Object.keys(this.world.room.textures.list)) {
+            if (['clothing', 'head', 'face', 'neck', 'body', 'hand', 'feet', 'puffles', 'paper', 'secret_frames'].includes(item.split('/')[0])) {
+                this.world.room.textures.remove(item)
+                textures++
+            }
+        }
+
+        for (let item of Object.keys(this.world.cache.audio.entries.entries)) {
+            if (['sfx'].includes(item.split('/')[0])) {
+                this.world.room.cache.audio.remove(item)
+                audio++
+            }
+        }
+
+        for (let item in this.world.room.anims.anims.entries) {
+            if (['head', 'face', 'neck', 'body', 'hand', 'feet', 'puffles'].includes(item.split('/')[0])) {
+                delete this.world.room.anims.anims.entries[item]
+                anims++
+            }
+
+            // Remove secret frame animations
+            if (['penguin'].includes(item.split('_')[0])) {
+                if (item.split('/')[0].split('_')[1] == 'body' && parseInt(item.split('/')[0].split('_')[2]) > 26) {
+                    delete this.world.room.anims.anims.entries[item]
+                    anims++
+                } else if (parseInt(item.split('/')[0].split('_')[1]) > 26) {
+                    delete this.world.room.anims.anims.entries[item]
+                    anims++
+                }
+            }
+        }
+
+        let stringArray = []
+        if (textures > 0) stringArray.push(`${textures} texture${textures > 1 ? 's' : ''}`)
+        if (json > 0) stringArray.push(`${json} json file${json > 1 ? 's' : ''}`)
+        if (audio > 0) stringArray.push(`${audio} audio file${audio > 1 ? 's' : ''}`)
+        if (video > 0) stringArray.push(`${video} video file${video > 1 ? 's' : ''}`)
+        if (anims > 0) stringArray.push(`${anims} animation${anims > 1 ? 's' : ''}`)
+        if (stringArray.length > 0) console.info(`[MemoryManager] Unloaded ${stringArray.join(', ')}`.replace(/,(?=[^,]+$)/, ', and'))
+
+        this.world.itemsLoaded = []
+    }
 }

--- a/src/engine/world/room/RoomFactory.js
+++ b/src/engine/world/room/RoomFactory.js
@@ -113,7 +113,7 @@ export default class RoomFactory {
         }
 
         for (let item in this.world.room.anims.anims.entries) {
-            if (['head', 'face', 'neck', 'body', 'hand', 'feet', 'puffles'].includes(item.split('/')[0])) {
+            if (item.startsWith("clothing/sprites/")) {
                 delete this.world.room.anims.anims.entries[item]
                 anims++
             }

--- a/src/engine/world/room/RoomFactory.js
+++ b/src/engine/world/room/RoomFactory.js
@@ -105,13 +105,6 @@ export default class RoomFactory {
             }
         }
 
-        for (let item of Object.keys(this.world.cache.audio.entries.entries)) {
-            if (['sfx'].includes(item.split('/')[0])) {
-                this.world.room.cache.audio.remove(item)
-                audio++
-            }
-        }
-
         for (let item in this.world.room.anims.anims.entries) {
             if (item.startsWith("clothing/sprites/")) {
                 delete this.world.room.anims.anims.entries[item]

--- a/src/scenes/interface/game/map/Map.js
+++ b/src/scenes/interface/game/map/Map.js
@@ -8,7 +8,8 @@ import IglooMap from './igloo_map/IglooMap'
 export const preload = {
     key: 'map-pack',
     url: 'assets/media/interface/game/map/map-pack.json',
-    loadString: ['loading', 'map']
+    loadString: ['loading', 'map'],
+    unload: false
 }
 
 /* START OF COMPILED CODE */

--- a/src/scenes/rooms/RoomScene.js
+++ b/src/scenes/rooms/RoomScene.js
@@ -53,6 +53,11 @@ export default class RoomScene extends BaseScene {
 
     preload() {
         this.load.on('progress', this.onProgress, this)
+
+        this.load.on('filecomplete', (key, type, data) =>{
+            this.world.loadedAssets.push({id: key, type})
+        })
+
         this.events.once('create', () => this.isReady = true)
 
         if (this.music && !this.cache.audio.exists(this.music)) {


### PR DESCRIPTION
By keeping track of every asset the client has loaded, we're then able to unload every unneeded asset when the player leaves the current room. This massively decreases VRAM usage, but increases loading time when users re-enter a room they have already visited.

Fixes #18 